### PR TITLE
Update deploy script to not depend on AppVeyor

### DIFF
--- a/FakeItEasy.Deploy/CommandLineOptions.cs
+++ b/FakeItEasy.Deploy/CommandLineOptions.cs
@@ -1,0 +1,83 @@
+namespace FakeItEasy.Deploy;
+
+internal class CommandLineOptions
+{
+    public string Repo { get; private set; } = string.Empty;
+    public string TagName { get; private set; } = string.Empty;
+    public string ArtifactsFolder { get; private set; } = string.Empty;
+
+    public static CommandLineOptions Parse(string[] args)
+    {
+        Action<string>? nextArgAction = null;
+        var options = new CommandLineOptions();
+        foreach (var arg in args)
+        {
+            if (nextArgAction is not null)
+            {
+                nextArgAction(arg);
+                nextArgAction = null;
+                continue;
+            }
+
+            switch (arg)
+            {
+                case "-r":
+                case "--repo":
+                    nextArgAction = value => options.Repo = value;
+                    break;
+                case "-t":
+                case "--tag-name":
+                    nextArgAction = value => options.TagName = value;
+                    break;
+                case "-a":
+                case "--artifacts-folder":
+                    nextArgAction = value => options.ArtifactsFolder = value;
+                    break;
+                default:
+                    ShowUsage();
+                    throw new Exception($"Unknown command line options '{arg}'");
+            }
+        }
+
+        return options;
+    }
+
+    public static void ShowUsage()
+    {
+        Console.WriteLine("Usage: <program> <options>");
+        Console.WriteLine("  -r|--repo              [REQUIRED] Repository (owner/repo)");
+        Console.WriteLine("  -t|--tag-name          [REQUIRED] Tag name");
+        Console.WriteLine("  -a|--artifacts-folder  [REQUIRED] Artifacts folder");
+    }
+
+    public bool Validate()
+    {
+        var errors = new List<string>();
+        if (string.IsNullOrEmpty(this.Repo))
+        {
+            errors.Add("Repository must be specified");
+        }
+
+        if (string.IsNullOrEmpty(this.TagName))
+        {
+            errors.Add("Tag name must be specified");
+        }
+
+        if (string.IsNullOrEmpty(this.ArtifactsFolder))
+        {
+            errors.Add("Artifacts folder must be specified");
+        }
+
+        if (errors.Any())
+        {
+            foreach (var error in errors)
+            {
+                Console.Error.WriteLine(error);
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/FakeItEasy.Deploy/CommandLineOptions.cs
+++ b/FakeItEasy.Deploy/CommandLineOptions.cs
@@ -1,15 +1,14 @@
 namespace FakeItEasy.Deploy;
 
-internal class CommandLineOptions
+internal record CommandLineOptions(string Repo, string TagName, string ArtifactsFolder, bool DryRun)
 {
-    public string Repo { get; private set; } = string.Empty;
-    public string TagName { get; private set; } = string.Empty;
-    public string ArtifactsFolder { get; private set; } = string.Empty;
-
     public static CommandLineOptions Parse(string[] args)
     {
         Action<string>? nextArgAction = null;
-        var options = new CommandLineOptions();
+        string repo = string.Empty;
+        string tagName = string.Empty;
+        string artifactsFolder = string.Empty;
+        bool dryRun = false;
         foreach (var arg in args)
         {
             if (nextArgAction is not null)
@@ -23,15 +22,19 @@ internal class CommandLineOptions
             {
                 case "-r":
                 case "--repo":
-                    nextArgAction = value => options.Repo = value;
+                    nextArgAction = value => repo = value;
                     break;
                 case "-t":
                 case "--tag-name":
-                    nextArgAction = value => options.TagName = value;
+                    nextArgAction = value => tagName = value;
                     break;
                 case "-a":
                 case "--artifacts-folder":
-                    nextArgAction = value => options.ArtifactsFolder = value;
+                    nextArgAction = value => artifactsFolder = value;
+                    break;
+                case "-d":
+                case "--dry-run":
+                    dryRun = true;
                     break;
                 default:
                     ShowUsage();
@@ -39,7 +42,7 @@ internal class CommandLineOptions
             }
         }
 
-        return options;
+        return new CommandLineOptions(repo, tagName, artifactsFolder, dryRun);
     }
 
     public static void ShowUsage()

--- a/FakeItEasy.Deploy/Program.cs
+++ b/FakeItEasy.Deploy/Program.cs
@@ -5,11 +5,13 @@ using static FakeItEasy.Tools.ReleaseHelpers;
 using static SimpleExec.Command;
 
 var options = CommandLineOptions.Parse(args);
-if (!options.Validate())
+if (options.ShowHelp)
 {
     CommandLineOptions.ShowUsage();
-    return 1;
+    return;
 }
+
+options.Validate();
 
 var releaseName = options.TagName;
 
@@ -59,7 +61,7 @@ if (!options.DryRun)
 
 Console.WriteLine("Finished deploying");
 
-return 0;
+return;
 
 static IEnumerable<Release> GetPreReleasesContributingToThisRelease(Release release, IReadOnlyList<Release> releases)
 {


### PR DESCRIPTION
- Take command-line options to specify the repo and tag, instead of looking at AppVeyor-specific environment variables
- The script still relies on the following environment variables being set:
  - NUGET_SERVER_URL
  - NUGET_API_KEY
  - GITHUB_TOKEN
- Added a dry-run mode to make it easier to test (runs "normally" but doesn't actually make any change)