### PR TITLE
Add reusable deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        type: string
+        required: true
+        description: "Name of the artifact to deploy"
+      docs-output-prefix:
+        type: string
+        required: true
+        description: "Path prefix where the docs will be generated"
+      dry-run:
+        type: boolean
+        required: true
+        description: "Dry run (doesn't actually publish anything)"
+    secrets:
+      NUGET_API_KEY:
+        required: true
+      BOT_GITHUB_TOKEN:
+        required: true
+
+env:
+  NUGET_SERVER_URL: https://www.nuget.org/
+  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+jobs:
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.event.inputs.artifact-name }}
+          path: /tmp/artifacts
+      - name: Deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event.inputs.dry-run }}" == "true" ]]; then
+            DRY_RUN_OPTION=--dry-run
+          fi
+          dotnet run --project tools-shared/FakeItEasy.Deploy -- $DRY_RUN_OPTION -r "${{ github.repository }}" -t "${{ github.ref_name }}" -a "/tmp/artifacts/output"
+
+  deploy-docs:
+    needs: deploy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Trigger docs generation
+        env:
+            GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          publishMode=auto-merge
+          if [[ "${{ github.event.inputs.dry-run }}" == "true" ]]; then
+            publishMode=none
+          fi
+          gh workflow run generate-docs.yml \
+            -R FakeItEasy/fakeiteasy.github.io \
+            -f output-prefix=${{ github.event.inputs.docs-output-prefix }} \
+            -f version=${{ github.ref_name }} \
+            -f source-repo=${{ github.repository }} \
+            -f source-ref=${{ github.ref_name }} \
+            -f publish-mode=$publishMode


### PR DESCRIPTION
Using this, the release.yml for FakeItEasy.Analyzers would now look like this:

```yml
name: Release

on:
  push:
    tags:
      - "*"
  workflow_dispatch:
    inputs:
      dry-run:
        type: boolean
        default: true
        description: "Dry run (doesn't actually publish anything)"

jobs:

  build:
    uses: ./.github/workflows/ci.yml

  deploy:
    needs: build
    uses: ./tools-shared/.github/workflows/deploy.yml
    with:
      artifact-name: windows-artifacts
      docs-output-prefix: "docs/analyzers"
      dry-run: ${{ github.event.inputs.dry-run == true }}
    secrets: inherit
```

(and the one for FakeItEasy would be almost the same, basically the only change would be the docs output prefix)