### PR TITLE
Use bot for deployment and docs generation

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -11,9 +11,9 @@ inputs:
   docs-output-prefix:
     required: true
     description: "Path prefix where the docs will be generated"
-  docs-workflow-token:
+  github-token:
     required: true
-    description: "GitHub token used to trigger the docs generation workflow"
+    description: "GitHub token to run the deployment and docs generation"
   dry-run:
     required: true
     description: "Dry run (doesn't actually publish anything)"
@@ -29,7 +29,7 @@ runs:
   - name: Deploy
     shell: bash
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ inputs.github-token }}
       NUGET_SERVER_URL: https://www.nuget.org/
       NUGET_API_KEY: ${{ inputs.nuget-api-key }}
     run: |
@@ -40,7 +40,7 @@ runs:
   - name: Trigger docs generation
     shell: bash
     env:
-      GH_TOKEN: ${{ inputs.docs-workflow-token }}
+      GH_TOKEN: ${{ inputs.github-token }}
     run: |
       publishMode=auto-merge
       if [[ "${{ inputs.dry-run }}" == "true" ]]; then

--- a/GitHubTokenSource.cs
+++ b/GitHubTokenSource.cs
@@ -7,7 +7,7 @@ public static class GitHubTokenSource
     public static string GetAccessToken()
     {
         var tokenFilePath = Path.Combine(GetCurrentScriptDirectory(), ".githubtoken");
-        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        var token = Environment.GetEnvironmentVariable("GH_TOKEN");
         if (string.IsNullOrEmpty(token))
         {
             if (File.Exists(tokenFilePath))
@@ -18,7 +18,7 @@ public static class GitHubTokenSource
 
         if (string.IsNullOrEmpty(token))
         {
-            throw new Exception($"GitHub access token is missing; please put it in '{tokenFilePath}', or in the GITHUB_TOKEN environment variable.");
+            throw new Exception($"GitHub access token is missing; please put it in '{tokenFilePath}', or in the GH_TOKEN environment variable.");
         }
 
         return token;


### PR DESCRIPTION
And rename the GITHUB_TOKEN environment variable to GH_TOKEN, to avoid confusion with the GITHUB_TOKEN secret.

Related to https://github.com/FakeItEasy/FakeItEasy/issues/1933