### PR TITLE
Support net8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
According to our [Platform support policy](https://fakeiteasy.github.io/docs/8.1.0/platform-support/) we should've released FakeItEasy on net8.0 by now. I'm working on a FakeItEasy/FakeItEasy pull request to do so and figured the tooling should be brought along.