### PR TITLE
Upgrade Octokit to 13.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
         <NoWarn>$(NoWarn),SA0001,SA1200,SA1516,CA1014,CA1812</NoWarn>
         <SimpleExecVersion>12.0.0</SimpleExecVersion>
         <NuGetVersion>6.9.1</NuGetVersion>
-        <OctokitVersion>10.0.0</OctokitVersion>
+        <OctokitVersion>13.0.0</OctokitVersion>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
10.0.0 was unable to parse newer issues, whose IDs no longer fit in an Int32.

Once merged and the new tools version is picked up, will fix FakeItEasy/FakeItEasy#2037