### PR TITLE
Update deploy action to use NuGet Trusted Publishing

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -5,9 +5,9 @@ inputs:
   artifact-name:
     required: true
     description: "Name of the artifact to deploy"
-  nuget-api-key:
+  nuget-user:
     required: true
-    description: "NuGet API key to publish the package"
+    description: "NuGet user name to publish the package"
   docs-output-prefix:
     required: true
     description: "Path prefix where the docs will be generated"
@@ -26,12 +26,17 @@ runs:
     with:
       name: ${{ inputs.artifact-name }}
       path: /tmp/artifacts
+  - name: NuGet login
+    uses: NuGet/login@v1
+    id: nuget-login
+    with:
+      user: ${{ inputs.nuget-user }}
   - name: Deploy
     shell: bash
     env:
       GH_TOKEN: ${{ inputs.github-token }}
       NUGET_SERVER_URL: https://www.nuget.org/
-      NUGET_API_KEY: ${{ inputs.nuget-api-key }}
+      NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
     run: |
       if [[ "${{ inputs.dry-run }}" == "true" ]]; then
         DRY_RUN_OPTION=--dry-run


### PR DESCRIPTION
Use [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) so that we no longer need to maintain an API key in the secrets.

The GH workflow will authenticate with NuGet based on the owner, repo and workflow name. I already defined a Trusted Publishing policy on Nuget.org:
<img width="1529" height="743" alt="image" src="https://github.com/user-attachments/assets/509ec292-66e8-494c-a2ba-da9fc97b77b5" />

I also created an org-level [variable](https://github.com/organizations/FakeItEasy/settings/variables/actions/NUGET_USER) with the NuGet user (I don't think it needs to be a secret, and it's more convenient to be able to see the value).